### PR TITLE
Change repository URL to that of the Java version

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Getting Started
 1. Open a terminal window or command shell
 1. Check out the repository and submodules
     ```
-    git clone --recursive https://github.com/Azure/azure-iot-pcs-remote-monitoring-dotnet.git
+    git clone --recursive https://github.com/Azure/azure-iot-pcs-remote-monitoring-java
     ```
 1. Set up command line interface for deployments
     ```


### PR DESCRIPTION
# Types of changes
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:
<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->
- [ ] All new and existing tests passed.
- [ ] The code follows the code style and conventions of this project.
- [x] The change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

# Description of the change
The README.md for the Java version should point to the Java repository URL

# Motivation for the change
So that developers reading README.md on GitHub via a browser get the right URL